### PR TITLE
AL-17807 - Fix Handlebars security vulnerability upgrade to 4.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "dependencies": {
         "camelcase": "^6.2.0",
         "commander": "^8.0.0",
-        "handlebars": "^4.7.6",
+        "handlebars": "^4.7.9",
         "js-yaml": "^4.0.0",
         "json-schema-ref-parser": "^9.0.7",
         "mkdirp": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3490,10 +3490,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==
 
-handlebars@^4.7.6:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"


### PR DESCRIPTION
## Summary
- Upgraded `handlebars` dependency from `^4.7.6` to `^4.7.9` to address a security vulnerability
- Updated `yarn.lock` with the resolved version `4.7.9`

## Jira
[AL-17807](https://causewayjira.atlassian.net/browse/AL-17807)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AL-17807]: https://causewayjira.atlassian.net/browse/AL-17807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ