### PR TITLE
ci: bump publish workflow Node from 20 to 24

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
       - run: npm ci
       - run: npm test
 
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0 # full history so we can check whether the tag already exists
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://npm.pkg.github.com/
 
       - name: Read version from package.json


### PR DESCRIPTION
## Summary

Updates the `node-version` in `.github/workflows/npm-publish-github-packages.yml`
from 20 → 24 in both the build and release jobs.

## Why

GitHub Actions is deprecating Node 20 runtimes and migrating action
internals to Node 24 in June 2026 — surfaced as a deprecation warning
during the v1.2.3 release run. Bumping our `node-version` ahead of the
forced migration:

- Keeps the build env aligned with what GitHub itself is standardising on
- Matches the version the alloy repos are targeting

## Notes

- Patch-level CI change only. No `package.json` version bump — the
  auto-publish workflow will see `1.2.3` on master, see the `v1.2.3` tag
  exists, and skip publishing (its designed no-op path).
- First chance to verify the "tag already exists → exit cleanly" branch
  of the workflow in production.

## Test plan

- [ ] Workflow runs after merge
- [ ] Build job goes green on Node 24
- [ ] Release job logs the "already released" branch and exits without
      attempting `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)